### PR TITLE
Refine drag and drop events to prevent interference with other drag/drop-sensitive fields in downstream use cases

### DIFF
--- a/src/uploads.js
+++ b/src/uploads.js
@@ -5,15 +5,15 @@ var classes = require('./classes');
 var dragClass = 'wk-dragging';
 var dragClassSpecific = 'wk-container-dragging';
 var root = document.documentElement;
-var dragginCss = 0;
+var dragginCss = 0; // variable to count the enter and leaving numbers.
 
 function uploads (container, droparea, editor, options, remove) {
   var op = remove ? 'remove' : 'add';
   crossvent[op](root, 'dragend', dragstopforce);
   crossvent[op](root, 'mouseout', dragstopforce);
   crossvent[op](container, 'dragover', handleDragOver, false);
-  crossvent[op](container, 'dragenter', dragging, false);
-  crossvent[op](container, 'dragleave', dragstop, false);
+  crossvent[op](container, 'dragenter', dragging, false);  // whenever the drag with components enter the container
+  crossvent[op](container, 'dragleave', dragstop, false);  // whenever the drag with components moves out of container
   crossvent[op](droparea, 'drop', handleFileSelect, false);
 
   function dragging () {

--- a/src/uploads.js
+++ b/src/uploads.js
@@ -5,25 +5,35 @@ var classes = require('./classes');
 var dragClass = 'wk-dragging';
 var dragClassSpecific = 'wk-container-dragging';
 var root = document.documentElement;
+var dragginCss = 0;
 
 function uploads (container, droparea, editor, options, remove) {
   var op = remove ? 'remove' : 'add';
-  crossvent[op](root, 'dragenter', dragging);
-  crossvent[op](root, 'dragend', dragstop);
-  crossvent[op](root, 'mouseout', dragstop);
+  crossvent[op](root, 'dragend', dragstopforce);
+  crossvent[op](root, 'mouseout', dragstopforce);
   crossvent[op](container, 'dragover', handleDragOver, false);
+  crossvent[op](container, 'dragenter', dragging, false);
+  crossvent[op](container, 'dragleave', dragstop, false);
   crossvent[op](droparea, 'drop', handleFileSelect, false);
 
   function dragging () {
+    dragginCss++;
     classes.add(droparea, dragClass);
     classes.add(droparea, dragClassSpecific);
   }
   function dragstop () {
+    dragginCss--;
+    if(dragginCss === 0){
+      dragstopper(droparea);
+    }
+  }
+  function dragstopforce () {
     dragstopper(droparea);
   }
   function handleDragOver (e) {
     stop(e);
-    dragging();
+    classes.add(droparea, dragClass);
+    classes.add(droparea, dragClassSpecific);
     e.dataTransfer.dropEffect = 'copy';
   }
   function handleFileSelect (e) {


### PR DESCRIPTION
This will improve publiclab/PublicLab.Editor#504.
After this fix, the drag and drop popup will only appear when it drags into proper div. Hence, in the editor module, the unnecessary popup will not appear.
Now if we drag and drop the image in Main Image Module the editor will not have a drag nd drop popup.

![woofmark2](https://user-images.githubusercontent.com/44112080/83393892-32192a80-a415-11ea-9b16-c9051c50a776.gif)

In this PR I have added one function that is dragginstopforce() this function will forcibly stop the CSS popup without checking the condition of entre or leave (i.e, it will not check the variable `draggingCss===0`). This function will be called every time on event `mouseout` and `dragend`.
Other than this function the pre-existing function are `dragging()` called on `dragenter` this function will add CSS popup including the `draggingCss++` , `handledragover` called on `dragover` this will add CSS popup including `stop(e)` and `draggingstop()` called on `dragover`.
The flow will be like this:- When the drag enters in the container the `dragenter` event calls `dragging()` function after this the dragging in the container will be handled by `dragover` and on leaving the container the event `dragover` will call the `dragginstop`.
In this process is the `mouseout` or `dragend` event occurs then `draggingstopforce` will be called.
Thank you. 