### PR TITLE
Feature to change heading back into plain text

### DIFF
--- a/src/html/heading.js
+++ b/src/html/heading.js
@@ -13,13 +13,18 @@ function heading (chunks) {
     swap();
   } else {
     add();
-  }
+  } 
 
   function swap () {
     var level = parseInt(lead[1], 10);
-    var next = level <= 1 ? 4 : level - 1;
+    var next = level > 3 ? remove() : level + 1;
     chunks.before = chunks.before.replace(rleading, '<h' + next + '>');
     chunks.after = chunks.after.replace(rtrailing, '</h' + next + '>');
+  }
+
+  function remove () {
+    chunks.before = chunks.before.replace(rleading, '');
+    chunks.after = chunks.after.replace(rtrailing, '');
   }
 
   function add () {

--- a/src/html/heading.js
+++ b/src/html/heading.js
@@ -15,8 +15,10 @@ function heading (chunks) {
     add();
   } 
 
+  // func changes headings
   function swap () {
     var level = parseInt(lead[1], 10);
+    // checks for the next heading size. Calls remove() if <h4> is reached.
     var next = level > 3 ? remove() : level + 1;
     chunks.before = chunks.before.replace(rleading, '<h' + next + '>');
     chunks.after = chunks.after.replace(rtrailing, '</h' + next + '>');
@@ -27,6 +29,7 @@ function heading (chunks) {
     chunks.after = chunks.after.replace(rtrailing, '');
   }
 
+  // func called to enter a new heading
   function add () {
     if (!chunks.selection) {
       chunks.selection = strings.placeholders.heading;

--- a/src/markdown/heading.js
+++ b/src/markdown/heading.js
@@ -38,6 +38,7 @@ function heading (chunks) {
   chunks.startTag = chunks.endTag = '';
   chunks.skip({ before: 1, after: 1 });
 
+  // checks the next heading size to implement. Changes to 0 if 4 is reached.
   var levelToCreate = level > 3 ? 0 : level + 1;
   if (levelToCreate === 0) {
     chunks.startTag = chunks.startTag.replace(/#+/, '');

--- a/src/markdown/heading.js
+++ b/src/markdown/heading.js
@@ -38,8 +38,11 @@ function heading (chunks) {
   chunks.startTag = chunks.endTag = '';
   chunks.skip({ before: 1, after: 1 });
 
-  var levelToCreate = level < 2 ? 4 : level - 1;
-  if (levelToCreate > 0) {
+  var levelToCreate = level > 3 ? 0 : level + 1;
+  if (levelToCreate === 0) {
+    chunks.startTag = chunks.startTag.replace(/#+/, '');
+  }
+  else {
     chunks.startTag = many('#', levelToCreate) + ' ';
   }
 }


### PR DESCRIPTION
Fixes publiclab/PublicLab.Editor#400 ie. converting headers back into plain text. 
Earlier, if a heading was added it could only be changed to different heading sizes and not to the plain text, for that one would have to delete the heading itself.  This PR enables the feature to convert heading back to plain text.

**Working:**
 Initially, the heading tag is `<h1>` , on clicking the heading button/ctrl+D it changes to `<h2>` and gradually decreases till `<h4>` (the minimum heading enabled in PLE), clicking after that would change it to plain text and the cycle restarts on clicking again.

Changes in HTML :

![PublicLab Editor-Google-Chrome-2020-06-16-13-53-18](https://user-images.githubusercontent.com/66686803/84751242-f6b45980-afd9-11ea-9f4e-2e58fa67df43.gif)

Changes in Markdown :

![PublicLab Editor-Google-Chrome-2020-06-16-13-54-12](https://user-images.githubusercontent.com/66686803/84751389-24010780-afda-11ea-967c-269ab0812d49.gif)

