### PR TITLE
Fix .gitpod.yml syntax (missing '-' in tasks)

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,9 +1,9 @@
 tasks:
-  init: |
+  - init: |
       npm install
       npm run build
       npm install http-server && node_modules/http-server/bin/http-server
-  command: |
+    command: |
       gp preview http://localhost:8080
 
 github:


### PR DESCRIPTION
Hello! I stumbled on your `.gitpod.yml` file while reading https://community.gitpod.io/t/cant-get-github-bot-to-appear-despite-app-install-and-config-file/1594 and I noticed that there was a YAML syntax error:

`tasks:` expects an Array of pre-configured Terminals, that can all run various commands in various phases. Here, I see that you have one Terminal (so one `-` expected), with two phases (`init` phase and `command` phase).